### PR TITLE
Expose the get_derivative function

### DIFF
--- a/src/aero.rs
+++ b/src/aero.rs
@@ -186,6 +186,18 @@ impl<T: Float, W: WindModel<T>, D: DensityModel<T>> AeroBody<T,W,D> {
         }
     }
     
+    /// Calculate the state derivative
+    /// 
+    /// NB: Gravity is included by default
+    /// 
+    /// # Arguments
+    /// * `state` - 13-dimensional state vector to get derivative about
+    /// * `forces` - Vector of applied forces, both world and body frame
+    /// * `torques` - Vector of applied torques, both world and body frame
+    pub fn get_derivative(&self, state: &StateVector<T>, forces: &[Force<T>], torques: &[Torque<T>]) -> StateVector<T> {
+        self.body.get_derivative(state, forces, torques)
+    }
+    
     /// Propagate the body state and wind_model by `delta_t` under the supplied `forces` and `torques`
     /// 
     /// See the documentation for [Body::step] for further details

--- a/src/aero.rs
+++ b/src/aero.rs
@@ -110,7 +110,7 @@ pub struct AeroBody<T: Float = DefaultFloatRepr, W: WindModel<T> = ConstantWind<
 }
 
 use crate::wind_models::ConstantWind;
-impl<T: Float> AeroBody<T,ConstantWind<T>,StandardDensity> {
+impl<T: Float> AeroBody<T,ConstantWind<T>,ConstantDensity> {
     /// Create an [AeroBody] with no wind and constant ISA standard sea-level density
     /// 
     /// # Arguments
@@ -122,7 +122,7 @@ impl<T: Float> AeroBody<T,ConstantWind<T>,StandardDensity> {
     }
 }
 
-impl<T: Float, W: WindModel<T>> AeroBody<T,W,StandardDensity> {
+impl<T: Float, W: WindModel<T>> AeroBody<T,W,ConstantDensity> {
     /// Create an AeroBody with a [WindModel] and constant ISA standard sea-level density
     /// 
     /// # Arguments
@@ -130,7 +130,7 @@ impl<T: Float, W: WindModel<T>> AeroBody<T,W,StandardDensity> {
     /// * `body` - The kinematics body to use
     /// * `wind_model` - The [WindModel] to use
     pub fn with_wind_model(body: Body<T>, wind_model: W) -> Self {
-        let density_model = StandardDensity{};
+        let density_model = ConstantDensity{};
         Self::with_density_model(body,wind_model,density_model)
     }
 }

--- a/src/effectors.rs
+++ b/src/effectors.rs
@@ -38,8 +38,8 @@ impl<I, T: Float, W: WindModel<T>, D: DensityModel<T>> AffectedBody<I,T,W,D> {
     /// * `state` - 13-dimensional state vector to get derivative about
     /// * `inputstate` - The input state to pass to the suplied [AeroEffect]s
     pub fn get_derivative(&self, state: &StateVector<T>, inputstate: &I) -> StateVector<T> {
-        let airstate = self.body.get_airstate();
-        let rates = self.body.rates();
+        let airstate = self.body.get_airstate_from_state(state);
+        let rates = state.rates();
         let ft_pairs = self.effectors.iter().map(|e| e.get_effect(airstate,rates,inputstate) );
         
         let mut forces = Vec::<Force<T>>::with_capacity(self.effectors.len());

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -78,7 +78,7 @@ impl<T: Float> Body<T> {
     /// 
     /// * `state` - The statevector to calculate the DCM for
     pub fn get_dcm(state: &StateVector<T>) -> Matrix3<T> {
-        // Don't use attitude here to avoid unessecary square root call
+        // Don't use attitude here to avoid unnecessary square root call
         let q = state.fixed_rows::<4>(6);
         let q0 = q[3]; let q02 = <T as num_traits::Float>::powi(q0,2); // Real part (w)
         let q1 = q[0]; let q12 = <T as num_traits::Float>::powi(q1,2); // i


### PR DESCRIPTION
For linearisation, the `get_derivative` function is useful to have access to.

This PR adds the ability to get the state derivative from Body/AeroBody for a particular state & applied forces and torques. It also adds a `get_derivative` function to `AffectedBody` that will retrieve the state derivative for a particular  state under the influence of the `AffectedBody`'s effects for a given control input.